### PR TITLE
Implement UUID4::valid?

### DIFF
--- a/lib/uuid4.rb
+++ b/lib/uuid4.rb
@@ -100,12 +100,10 @@ class UUID4
         return value
       end
 
-      FORMATTERS.each do |formatter|
-        val = formatter.decode(value) if formatter.respond_to?(:decode)
-        return val if val
-      end
-
-      nil
+      # Return the result of the first formatter that can decode this value
+      FORMATTERS.lazy.map { |formatter|
+        formatter.decode(value) if formatter.respond_to?(:decode)
+      }.find(&:itself)
     end
 
     def valid_int?(int)

--- a/lib/uuid4.rb
+++ b/lib/uuid4.rb
@@ -95,6 +95,13 @@ class UUID4
       end
     end
 
+    def valid?(value)
+      new(value)
+      true
+    rescue TypeError
+      false
+    end
+
     def _parse(value)
       if value.respond_to?(:to_int) && valid_int?(value = value.to_int)
         return value

--- a/spec/uuid4_spec.rb
+++ b/spec/uuid4_spec.rb
@@ -51,6 +51,45 @@ describe UUID4 do
     end
   end
 
+  describe '#valid?' do
+    subject { UUID4.valid?(value) }
+
+    context 'with string' do
+      let(:value) { uuid_str }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with compact string' do
+      let(:value) { uuid_cmp }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with integer' do
+      let(:value) { uuid_int }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with base62 string' do
+      let(:value) { uuid_b62 }
+      it { is_expected.to be_truthy }
+
+      context 'with shorter base62 string' do
+        let(:value) { '1vGiOCdOqnKYhO' }
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    context 'with urn string' do
+      let(:value) { uuid_urn }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with random string' do
+      let(:value) { 'abcde' }
+      it { is_expected.to be_falsy }
+    end
+  end
+
   describe '#to_s' do
     subject { uuid.to_s }
     it { is_expected.to be_a String }


### PR DESCRIPTION
- Implement `UUID4::valid?` to validate objects as UUIDs.
- Test the method.

And a slightly more functional version of the decoding logic. :)

Not sure whether you like this approach to validation (using the parser and checking whether there is an exception). It might make more sense to only check string values here and invoke the formatters in the `valid?` method itself. This would also allow us to easily add a second parameter to specify a formatter if we just want to check against one serialization format.
