### PR TITLE
Fix TypeError message text

### DIFF
--- a/lib/uuid4.rb
+++ b/lib/uuid4.rb
@@ -93,8 +93,8 @@ class UUID4
     def new(value = nil)
       if value.nil?
         super(SecureRandom.uuid.tr('-', '').hex)
-      elsif (value = try_convert(value))
-        value
+      elsif (uuid = try_convert(value))
+        uuid
       else
         raise TypeError.new "Invalid UUID: #{value.inspect}"
       end

--- a/spec/uuid4_spec.rb
+++ b/spec/uuid4_spec.rb
@@ -49,6 +49,16 @@ describe UUID4 do
       let(:value) { uuid_urn }
       it { expect(subject.to_str).to eq uuid_str }
     end
+
+    context 'with invalid string' do
+      let(:value) { 'this-is-not-a-uuid' }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(TypeError) do |err|
+          expect(err.message).to include(value)
+        end
+      end
+    end
   end
 
   describe '.try_convert' do


### PR DESCRIPTION
UUID4 initialize raises an TypeError for unsupported input values. The
error message should reference the invalid value (simplifies debugging).
It has always reported `nil` as the original input value had been
overridden. This commit fixes this.