### PR TITLE
Consider newlines when checking base62 format

### DIFF
--- a/lib/uuid4/formatter/base62.rb
+++ b/lib/uuid4/formatter/base62.rb
@@ -3,7 +3,7 @@ require 'base62-rb'
 class UUID4
   module Formatter
     class Base62
-      REGEXP = /^[0-9A-Za-z]{14,22}$/
+      REGEXP = /\A[0-9A-Za-z]{14,22}\z/
 
       def encode(uuid)
         ::Base62.encode(uuid.to_i)

--- a/spec/uuid4_spec.rb
+++ b/spec/uuid4_spec.rb
@@ -139,6 +139,11 @@ describe UUID4 do
       let(:value) { 'abcdefg_ijkl6574mno' }
       it { expect(subject).to be_nil }
     end
+
+    context 'with invalid base62 string (valid + newline)' do
+      let(:value) { "mainframes2018\nmumbojumbo" }
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#valid?' do


### PR DESCRIPTION
The regular expression that determine whether a string could be a Base-62-encoded UUID used newline-sensitive anchors.

Thus, it only verified the first line of a given string matched the expected format, but then passed on the entire string (including the newline and following characters) to the base 62 decoder, which could error.